### PR TITLE
Add RTP — Robot Task Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A collection of useful links discovered through the work on [Weekly Robotics](ht
  * [Fields2Cover](https://github.com/Fields2Cover/Fields2Cover) - A modular and extensible Coverage Path Planning library. Licence: BSD-3-Clause.
  * [Segment Anything](https://github.com/facebookresearch/segment-anything) - The Segment Anything Model (SAM) produces high quality object masks from input prompts such as points or boxes, and it can be used to generate masks for all objects in an image. Licence: Apache 2.0.
  * [LeRobot](https://github.com/huggingface/lerobot) - Developped by Hugging Face, LeRobot provides models, datasets and tools for real-world robotics in PyTorch. Licence: Apache 2.0.
+ * [RTP — Robot Task Protocol](https://github.com/plagtech/rtp-spec) - An open standard and TypeScript SDK for AI agents to discover, commission, and pay robots for physical tasks via HTTP micropayments (x402). Supports ROS robots, drones, Raspberry Pi, industrial arms, and IoT devices. Licence: MIT.
 
 ### SLAM
  * [Cartographer](https://github.com/googlecartographer/cartographer) - 2D and 3D SLAM library, supports multiple platforms and sensor configurations. Licence: Apache 2.0.


### PR DESCRIPTION
RTP (Robot Task Protocol) is an open protocol that defines how AI agents discover, commission, and pay for physical robot tasks over HTTP.

Think of it as the economic layer for robotics — any device that can receive a command and report a result can become a payable endpoint. Agents pay per task in USDC via the x402 protocol.

The spec includes a task envelope schema, 15 standard capability verbs, a lifecycle state machine with escrow, and a device compatibility guide covering 7 hardware categories.

- Spec: https://github.com/plagtech/rtp-spec
- Live gateway: https://gateway.spraay.app
- MIT licensed