### PR TITLE
Add Physical AI Atlas to Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ A collection of useful links discovered through the work on [Weekly Robotics](ht
  * [OSRTOS](https://www.osrtos.com/) - A list of open source Real Time Operating Systems (RTOS). Licence: CC BY-SA 3.0.
  * [Haptipedia](https://haptipedia.org/) - An online, open-source, visualization of a growing database of 105+ haptic devices invented since 1992.
  * [Board-DB](https://www.hackerboards.com) - A searchable database of single board computers.
+ * [Physical AI Atlas](https://github.com/PlbKin190/physical-ai-atlas-data) - Curated bilingual (FR/EN) database of 320 entities in the physical AI ecosystem: humanoid robots, platforms, VLA models, chips, labs and companies, with an EMEA lens and per-entity verification dates. Licence: CC BY 4.0.
  * [A fast introduction to Robotics (v 2.0)](https://medium.com/@harshmaithani09/a-fast-introduction-to-robotics-v-2-0-6d07516e053f) - A hand-picked selection of Robotics resources covering robotics from various angles.
  * [ContinuumRobotExamples](https://github.com/JohnDTill/ContinuumRobotExamples) - Continuum robots have elastic links which are capable of large-scale continuous deformations. This repo has example scripts to simulate continuum robots of various design paradigms. Each example is accompanied by a short write-up in PDF format. Licence: MIT.
  * [AI Incident Database](https://incidentdatabase.ai/summaries/incidents) - a well documented database of AI incidents.


### PR DESCRIPTION
Adds [Physical AI Atlas](https://github.com/PlbKin190/physical-ai-atlas-data) to the Other section, alongside Haptipedia and Board-DB — same kind of curated reference database, applied to physical AI.

An open dataset (CC BY 4.0) mapping 320 entities: humanoid robots, robotic platforms, VLA models, embedded AI chips, simulators, research labs and companies. Bilingual (FR/EN), each entity carries a per-entity verification date, and it has a deliberate EMEA lens.

Browsable version: https://www.d-fairy.fr/atlas/

Happy to adjust wording or placement if it fits better elsewhere.