### PR TITLE
Add mlx-smolvla (MLX-native SmolVLA runtime for Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A collection of useful links discovered through the work on [Weekly Robotics](ht
  * [Fields2Cover](https://github.com/Fields2Cover/Fields2Cover) - A modular and extensible Coverage Path Planning library. Licence: BSD-3-Clause.
  * [Segment Anything](https://github.com/facebookresearch/segment-anything) - The Segment Anything Model (SAM) produces high quality object masks from input prompts such as points or boxes, and it can be used to generate masks for all objects in an image. Licence: Apache 2.0.
  * [LeRobot](https://github.com/huggingface/lerobot) - Developped by Hugging Face, LeRobot provides models, datasets and tools for real-world robotics in PyTorch. Licence: Apache 2.0.
+ * [mlx-smolvla](https://github.com/daniiarabdiev/mlx-smolvla) - MLX-native SmolVLA inference on Apple Silicon, with LeRobot-protocol serving and preview LoRA fine-tuning. Licence: Apache 2.0.
  * [LiveKit](https://github.com/livekit/livekit) - LiveKit is an open-source WebRTC SFU & SDKs to enable low-latency realtime streaming of video, audio, & data.  SDKs available in [Rust](https://github.com/livekit/rust-sdks), [Python](https://github.com/livekit/python-sdks), [C++](https://github.com/livekit/client-sdk-cpp), [Javascript](https://github.com/livekit/client-sdk-js), [Swift](https://github.com/livekit/client-sdk-swift), [Kotlin](https://github.com/livekit/client-sdk-android), [Unity](https://github.com/livekit/client-sdk-unity), [Flutter](https://github.com/livekit/client-sdk-flutter), [ESP32](https://github.com/livekit/client-sdk-esp32).  License: Apache 2.0.
 
 ### SLAM


### PR DESCRIPTION
Proposes my mlx-smolvla package for Libraries and Frameworks, next to the LeRobot ecosystem resources. It runs SmolVLA checkpoints on Apple Silicon through MLX, implements LeRobot-protocol serving, and includes preview LoRA fine-tuning; the hardware loop remains unvalidated for task success.

https://github.com/daniiarabdiev/mlx-smolvla

Prior art: tokimoa/smolvla-mlx (Hugging Face, 2026-07-29) is an earlier independent inference-only SmolVLA-to-MLX port; tokimoa also published pi0-mlx and groot-n1.7-mlx. The SmolVLM implementation in mlx-vlm was an architecture reference, with no runtime dependency. mlx-smolvla is not a fork of either.
